### PR TITLE
[Add] - Pytorch Dataset for parsing ESC-50 and Mapping to Hypercatego…

### DIFF
--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -1,0 +1,16 @@
+ESC_CLASS_MAPPING = {
+    "Animals": 0,
+    "Natural soundscapes & water sounds": 1,
+    "Human, non-speech sounds": 2,
+    "Interior/domestic sounds": 3,
+    "Exterior/urban noises": 4
+}
+
+ESC_INV_CLASS_MAPPING = {
+    0: "Animals",
+    1: "Natural soundscapes & water sounds",
+    2: "Human, non-speech sounds",
+    3: "Interior/domestic sounds",
+    4: "Exterior/urban noises"
+}
+

--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -1,0 +1,80 @@
+import os
+import sys
+from typing import Optional, List
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from torch.utils.data import Dataset
+import pandas as pd
+import librosa
+
+from utils.utils import crawl_directory
+from datasets import ESC_CLASS_MAPPING, ESC_INV_CLASS_MAPPING
+
+
+class ESC50Dataset(Dataset):
+    """Dataset Class for ESC-50 Hypercategory Parsing"""
+
+    def __init__(self,
+                 data_path: os.PathLike,
+                 metadata_csv: os.PathLike,
+                 hypercategory_mapping: os.PathLike,
+                 folds: Optional[List[int]] = None):
+        """
+        Args:
+            data_path (os.PathLike): Abs Path to wav files of ESC-50.
+            metadata_csv (os.PathLike): Abs Path to metadata csv.
+            hypercategory_mapping (os.PathLike): Abs Path to hypercategory mapping json.
+            folds (List[int]): List of folds to filter wav files.
+        """
+
+        # Parse wav files
+        self.wav_files = crawl_directory(directory=data_path, extension=".wav")
+        self.metadata_df = pd.read_csv(metadata_csv)
+        self.hypercategory_mapping = self.parse_hypercategory_mapping(hypercategory_mapping)
+
+        # Filter on folds
+        if folds:
+            self.metadata_df = self.metadata_df[self.metadata_df['fold'].isin(folds)]
+
+        # Create List[wav_path, label, hypercategory, label int]
+        wavs_to_keep = self.metadata_df['filename'].tolist()
+        self.items = []
+        for wav_file in self.wav_files:
+            filename = os.path.basename(wav_file)
+            if filename in wavs_to_keep:
+                
+                # Get waveform
+                y, sr = librosa.load(wav_file, sr=16_000)
+                
+                row_dict = self.metadata_df[self.metadata_df['filename'] == filename].iloc[0].to_dict()
+                sample_hypercategory = self.hypercategory_mapping[row_dict['category']]
+                
+                self.items.append({
+                    "filename": wav_file,
+                    "class": row_dict['category'],
+                    "fold": row_dict['fold'],
+                    "hypercategory": sample_hypercategory,
+                    "label": ESC_CLASS_MAPPING[sample_hypercategory],
+                    "waveform": y
+                })
+    
+    def __getitem__(self, idx):
+        return self.items[idx]
+    
+    def __len__(self):
+        return len(self.items)
+
+    def parse_hypercategory_mapping(self, json_file: os.PathLike):
+        """Parse hypercategory mapping as dict.
+        
+        Args:
+            json_file (os.PathLike): Abs Path to hypercategory mapping
+        Returns:
+            Dict[str, str]
+        """
+
+        with open(json_file, "r") as f:
+            hypercategory_mapping = json.load(f)
+        return hypercategory_mapping


### PR DESCRIPTION
This PR closes #22. A PyTorch dataset for parsing the ESC-50 dataset has been added. To test the dataset you'll need to have locally the json hypercategory mapping the esc-50 classes to the 5 hypercategories.

The following example demonstrates the usage of the PyTorch dataset.

```python

from datasets.datasets import ESC50Dataset

json_hypercategory = "esc50_hypercatgory_mapping.json" # Hypercategory Mapping
data_path = "/data/ESC-50-master/Sorted/" # Full Path to the Wav files of ESC-50
metadata_csv = "/data/ESC-50-master/meta/esc50.csv" # Full Path to Metadata csv

d_set = ESC50Dataset(data_path=data_path, metadata_csv=metadata_csv, hypercategory_mapping=json_hypercategory)

s = d_set[0]

s.keys()

dict_keys(['filename', 'class', 'fold', 'hypercategory', 'label', 'waveform'])
```

The variable `s` contains a Python dictionary with the above keys. You can inspect the values of these keys. Additionally, the class accepts an extra argument `folds` with the number of folds to keep. For example, if you call

```python
d_set = ESC50Dataset(data_path=data_path, metadata_csv=metadata_csv, hypercategory_mapping=json_hypercategory, folds=[1, 2, 3])
```

Then only the wav files corresponding to the first three folds will be returned through the `__getitem__` method.


Please check @vasilistheiou 